### PR TITLE
[Upgrade] Remove psycopg2-binary and add pg8000

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+asn1crypto==1.5.1
 attrs==23.1.0
 aws-sam-translator==1.71.0
 aws-xray-sdk==2.12.0
@@ -43,10 +44,10 @@ packaging==23.1
 paramiko==3.2.0
 pathable==0.4.3
 pbr==5.11.1
+pg8000==1.29.8
 pkgutil_resolve_name==1.3.10
 platformdirs==3.8.1
 pluggy==1.2.0
-psycopg2-binary==2.9.6
 py-partiql-parser==0.3.3
 pyasn1==0.5.0
 pycparser==2.21
@@ -68,6 +69,7 @@ rpds-py==0.8.10
 rsa==4.9
 s3transfer==0.6.1
 sarif-om==1.0.4
+scramp==1.4.4
 six==1.16.0
 sshpubkeys==3.3.1
 sympy==1.12

--- a/src/pipeline/clients/database.py
+++ b/src/pipeline/clients/database.py
@@ -7,13 +7,14 @@ class PostgresClient:
         self.cursor = connection
 
     def get_distinct_sources(self, schema: str, table_name: str) -> set:
-        self.cursor.execute(f"""select distinct source_file_name from {schema}.{table_name};""")
         
-        return set([source[0] for source in self.cursor.fetchall()])
+        result = self.cursor.run(f"""select distinct source_file_name from {schema}.{table_name};""")
+        
+        return set([source[0] for source in result])
 
     def delete_sources(self, schema: str, table_name: str, sources: list) -> set:
 
         edit = (',').join([f"'{source}'" for source in sources])
 
-        self.cursor.execute(f"""delete from {schema}.{table_name} where source_file_name in ({edit});""")
+        self.cursor.run(f"""delete from {schema}.{table_name} where source_file_name in ({edit});""")
         

--- a/src/pipeline/connections/postgres.py
+++ b/src/pipeline/connections/postgres.py
@@ -1,19 +1,16 @@
 from contextlib import contextmanager
 from dataclasses import asdict
 
-import psycopg2
+import pg8000.native
 
 from pipeline.config.connections import PostgresConnectionConfig
 
 @contextmanager
 def database_connection(postgres_connection_config: PostgresConnectionConfig):
     
-    database_connection = psycopg2.connect(**asdict(postgres_connection_config))
-    database_connection.autocommit = True
+    connection = pg8000.native.Connection(**asdict(postgres_connection_config))
 
     try:
-        cursor = database_connection.cursor()
-        yield cursor
+        yield connection
     finally:
-        cursor.close()
-        database_connection.close()
+        connection.close()

--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -9,8 +9,8 @@ import pytest
 def setup():
     with database_connection(get_postgres_connection_credentials()) as connection:
 
-        connection.execute(f"""truncate table production.trades;""")
-        connection.execute("""
+        connection.run(f"""truncate table production.trades;""")
+        connection.run("""
             INSERT INTO production.trades (id, ticker, price, quantity, status, source_file_name)
             VALUES 
                 (1, 'TSLA', 100.00, 10, 'OPEN', '2023-06-23-trades-1'),
@@ -36,7 +36,8 @@ def test_postgres_client_delete_sources(setup):
         client = PostgresClient(connection=connection)
         client.delete_sources(schema='production', table_name='trades', sources=['2023-06-24-trades-1'])
 
-        connection.execute(f"""select distinct source_file_name from production.trades;""")
-        result = sorted(set([source[0] for source in connection.fetchall()]))
-
-        assert result == ['2023-06-23-trades-1', '2023-06-23-trades-2']
+        test = sorted(set(row[0] for row in connection.run(f"""select distinct source_file_name from production.trades;""")))
+        
+        # result = sorted(set([source[0] for source in connection.fetchall()]))
+      
+        assert test == ['2023-06-23-trades-1', '2023-06-23-trades-2']


### PR DESCRIPTION
- Psycopg2 is more difficult to manage in a AWS lambda function
- This removes it in favour of pg8000 which does not have the same issues